### PR TITLE
Add issue processing action table to output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@ hs_err_pid*
 
 nbproject/
 target/
+output/
+.idea/
+.vscode/
+git_hub_authentication_file.properties
+log.out
+.DS_store
 Reliability-Tool-Core/IssuesDB/
 *.txt

--- a/Core/src/main/java/fi/muni/cz/core/ArgsParser.java
+++ b/Core/src/main/java/fi/muni/cz/core/ArgsParser.java
@@ -490,7 +490,7 @@ public class ArgsParser {
      * 
      * @return argument values.
      */
-    public String[] getOptionValuesFilterLables() {
+    public String[] getOptionValuesFilterLabels() {
         return cmdl.getOptionValues(OPT_FILTER_LABELS);
     }
     

--- a/Core/src/main/java/fi/muni/cz/core/Core.java
+++ b/Core/src/main/java/fi/muni/cz/core/Core.java
@@ -239,9 +239,14 @@ public class Core {
                                 ? parsedUrlData.getRepositoryName() : PARSER.getOptionValueEvaluation());
     }
     
-    private static List<OutputData> prepareOutputData(int initialNumberOfIssues, 
-            List<GeneralIssue> listOfGeneralIssues, List<Pair<Integer, Integer>> countedWeeksWithTotal, 
-            TrendTest trendTest, RepositoryInformation repositoryInformation) throws InvalidInputException {
+    private static List<OutputData> prepareOutputData(
+            int initialNumberOfIssues,
+            List<GeneralIssue> listOfGeneralIssues,
+            List<Pair<Integer, Integer>> countedWeeksWithTotal,
+            TrendTest trendTest,
+            RepositoryInformation repositoryInformation,
+            IssueProcessingStrategy issueProcessingStrategy)
+            throws InvalidInputException {
         List<OutputData> outputDataList = new ArrayList<>();
         OutputData outputData;
         for (Model model: runModels(countedWeeksWithTotal, getGoodnessOfFitTest())) {
@@ -263,6 +268,7 @@ public class Core {
                     .setInitialNumberOfIssues(initialNumberOfIssues)
                     .setFiltersUsed(FilterFactory.getFiltersRanWithInfoAsList(PARSER))
                     .setProcessorsUsed(ProcessorFactory.getProcessorsRanWithInfoAsList(PARSER))
+                    .setIssueProcessingActionResults(issueProcessingStrategy.getIssueProcessingActionResults())
                     .setTestingPeriodsUnit(getPeriodOfTesting())
                     .setTimeBetweenDefectsUnit(getTimeBetweenIssuesUnit())
                     .setSolver(getSolver())
@@ -282,7 +288,7 @@ public class Core {
 
         if (outputDataList.isEmpty()) {
             outputData = getOutputDataForNoModels(initialNumberOfIssues, listOfGeneralIssues,
-                    countedWeeksWithTotal, trendTest, repositoryInformation);
+                    countedWeeksWithTotal, trendTest, repositoryInformation, issueProcessingStrategy);
             outputDataList.add(outputData);
         }
 
@@ -293,7 +299,8 @@ public class Core {
                                                        List<GeneralIssue> listOfGeneralIssues,
                                                        List<Pair<Integer, Integer>> countedWeeksWithTotal,
                                                        TrendTest trendTest,
-                                                       RepositoryInformation repositoryInformation) {
+                                                       RepositoryInformation repositoryInformation,
+                                                       IssueProcessingStrategy issueProcessingStrategy) {
         return new OutputData.OutputDataBuilder()
                 .setCreatedAt(new Date())
                 .setRepositoryName(parsedUrlData.getRepositoryName())
@@ -308,6 +315,7 @@ public class Core {
                 .setInitialNumberOfIssues(initialNumberOfIssues)
                 .setFiltersUsed(FilterFactory.getFiltersRanWithInfoAsList(PARSER))
                 .setProcessorsUsed(ProcessorFactory.getProcessorsRanWithInfoAsList(PARSER))
+                .setIssueProcessingActionResults(issueProcessingStrategy.getIssueProcessingActionResults())
                 .setTestingPeriodsUnit(getPeriodOfTesting())
                 .setTimeBetweenDefectsUnit(getTimeBetweenIssuesUnit())
                 .setSolver(getSolver())
@@ -346,7 +354,11 @@ public class Core {
         TrendTest trendTest = runTrendTest(filteredAndProcessedList); 
         List<OutputData> outputDataList = 
                 prepareOutputData(listOfGeneralIssues.size(), 
-                        filteredAndProcessedList, countedWeeksWithTotal, trendTest, repositoryInformation);
+                        filteredAndProcessedList,
+                        countedWeeksWithTotal,
+                        trendTest,
+                        repositoryInformation,
+                        issueProcessingStrategy);
         writeOutput(outputDataList);
     }
 

--- a/Core/src/main/java/fi/muni/cz/core/Core.java
+++ b/Core/src/main/java/fi/muni/cz/core/Core.java
@@ -168,7 +168,7 @@ public class Core {
         filteredList.addAll(listOfGeneralIssues);
         List<Filter> listOfFilters = FilterFactory.getFilters(PARSER);
         for (Filter filter: listOfFilters) {
-            filteredList = filter.filter(filteredList);
+            filteredList = filter.apply(filteredList);
         }
         return filteredList;
     } 
@@ -247,7 +247,7 @@ public class Core {
         processedList.addAll(listOfGeneralIssues);
         List<IssuesProcessor> listOfProcessors = ProcessorFactory.getProcessors(PARSER);
         for (IssuesProcessor processor: listOfProcessors) {
-            processedList = processor.process(processedList);
+            processedList = processor.apply(processedList);
         }
         return processedList;
     }

--- a/Core/src/main/java/fi/muni/cz/core/Core.java
+++ b/Core/src/main/java/fi/muni/cz/core/Core.java
@@ -2,8 +2,7 @@ package fi.muni.cz.core;
 
 import fi.muni.cz.core.exception.InvalidInputException;
 import fi.muni.cz.core.factory.*;
-import fi.muni.cz.dataprocessing.issuesprocessing.Filter;
-import fi.muni.cz.dataprocessing.issuesprocessing.IssuesProcessor;
+import fi.muni.cz.dataprocessing.issuesprocessing.IssueProcessingStrategy;
 import fi.muni.cz.dataprocessing.issuesprocessing.modeldata.CumulativeIssuesCounter;
 import fi.muni.cz.dataprocessing.issuesprocessing.modeldata.IssuesCounter;
 import fi.muni.cz.dataprocessing.issuesprocessing.modeldata.TimeBetweenIssuesCounter;
@@ -32,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Radoslav Micko, 445611@muni.cz
@@ -162,17 +162,7 @@ public class Core {
         System.out.println("On repository - " + snapshot.getUrl());
         doEvaluate(snapshot.getListOfGeneralIssues(), snapshot.getRepositoryInformation());
     }
-    
-    private static List<GeneralIssue> runFilters(List<GeneralIssue> listOfGeneralIssues) {
-        List<GeneralIssue> filteredList = new ArrayList<>();
-        filteredList.addAll(listOfGeneralIssues);
-        List<Filter> listOfFilters = FilterFactory.getFilters(PARSER);
-        for (Filter filter: listOfFilters) {
-            filteredList = filter.apply(filteredList);
-        }
-        return filteredList;
-    } 
-    
+
     private static String getPeriodOfTesting() {
         if (PARSER.hasOptionPeriodOfTestiong()) {
             return PARSER.getOptionValuePeriodOfTesting();
@@ -242,35 +232,11 @@ public class Core {
         return 0;
     }
     
-    private static List<GeneralIssue> runProcessors(List<GeneralIssue> listOfGeneralIssues) {
-        List<GeneralIssue> processedList = new ArrayList<>();
-        processedList.addAll(listOfGeneralIssues);
-        List<IssuesProcessor> listOfProcessors = ProcessorFactory.getProcessors(PARSER);
-        for (IssuesProcessor processor: listOfProcessors) {
-            processedList = processor.apply(processedList);
-        }
-        return processedList;
-    }
-    
     private static void writeOutput(List<OutputData> outputDataList) throws InvalidInputException {
         OutputWriterFactory.getIssuesWriter(PARSER)
                 .writeOutputDataToFile(outputDataList,
                         PARSER.getOptionValueEvaluation() == null
                                 ? parsedUrlData.getRepositoryName() : PARSER.getOptionValueEvaluation());
-    }
-    
-    private static List<GeneralIssue> runFiltersAndProcessors(List<GeneralIssue> listOfGeneralIssues) {
-        List<GeneralIssue> filteredList = checkFilteredListForEmpty(runFilters(listOfGeneralIssues));
-        filteredList = runProcessors(filteredList);
-        return filteredList;
-    }
-    
-    private static List<GeneralIssue> checkFilteredListForEmpty(List<GeneralIssue> filteredList) {
-        if (filteredList.isEmpty()) {
-            System.out.println("[There are no issues after filtering]");
-            System.exit(1);
-        }
-        return filteredList;
     }
     
     private static List<OutputData> prepareOutputData(int initialNumberOfIssues, 
@@ -372,13 +338,25 @@ public class Core {
     private static void doEvaluate(List<GeneralIssue> listOfGeneralIssues,
                                    RepositoryInformation repositoryInformation) throws InvalidInputException {
         System.out.println("Evaluating ...");
-        List<GeneralIssue> filteredAndProcessedList = runFiltersAndProcessors(listOfGeneralIssues);
+
+        IssueProcessingStrategy issueProcessingStrategy = getStrategyFromParser();
+
+        List<GeneralIssue> filteredAndProcessedList = issueProcessingStrategy.apply(listOfGeneralIssues);
         List<Pair<Integer, Integer>> countedWeeksWithTotal = getCumulativeIssuesList(filteredAndProcessedList); 
         TrendTest trendTest = runTrendTest(filteredAndProcessedList); 
         List<OutputData> outputDataList = 
                 prepareOutputData(listOfGeneralIssues.size(), 
                         filteredAndProcessedList, countedWeeksWithTotal, trendTest, repositoryInformation);
         writeOutput(outputDataList);
+    }
+
+    private static IssueProcessingStrategy getStrategyFromParser(){
+        return new IssueProcessingStrategy(
+                Stream.concat(
+                        FilterFactory.getFilters(PARSER).stream(),
+                        ProcessorFactory.getProcessors(PARSER).stream()).collect(
+                        Collectors.toList()),
+                "");
     }
 
     private static void doSaveToFileFromUrl() throws InvalidInputException {
@@ -394,7 +372,11 @@ public class Core {
     
     private static void doSaveToFile(List<GeneralIssue> listOfInitialIssues, String fileName) 
             throws InvalidInputException {
-        IssuesWriterFactory.getIssuesWriter(PARSER).writeToFile(runFilters(listOfInitialIssues), fileName);
+        IssuesWriterFactory
+                .getIssuesWriter(PARSER)
+                .writeToFile(
+                        getStrategyFromParser().apply(listOfInitialIssues), fileName
+                );
     }
 
     private static void doListAllSnapshots() {

--- a/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
+++ b/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
@@ -28,7 +28,7 @@ public class FilterFactory {
      */
     public static List<String> getFiltersRanWithInfoAsList(ArgsParser parser) {
         List<String> list = new ArrayList<>();
-        for (Filter filter: getFilters(parser)) {
+        for (IssueProcessingAction filter: getFilters(parser)) {
             list.add(filter.infoAboutIssueProcessingAction());
         }
         return list;
@@ -40,8 +40,8 @@ public class FilterFactory {
      * @param parser  parsed CommandLine.
      * @return list of Filters.
      */
-    public static List<Filter> getFilters(ArgsParser parser) {
-        List<Filter> listOfFilters = new ArrayList<>();
+    public static List<IssueProcessingAction> getFilters(ArgsParser parser) {
+        List<IssueProcessingAction> listOfFilters = new ArrayList<>();
         
         if (parser.hasOptionFilterLabels()) {
             if (parser.getOptionValuesFilterLabels() == null) {

--- a/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
+++ b/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
@@ -29,7 +29,7 @@ public class FilterFactory {
     public static List<String> getFiltersRanWithInfoAsList(ArgsParser parser) {
         List<String> list = new ArrayList<>();
         for (Filter filter: getFilters(parser)) {
-            list.add(filter.infoAboutFilter());
+            list.add(filter.infoAboutIssueProcessingAction());
         }
         return list;
     }

--- a/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
+++ b/Core/src/main/java/fi/muni/cz/core/factory/FilterFactory.java
@@ -44,11 +44,11 @@ public class FilterFactory {
         List<Filter> listOfFilters = new ArrayList<>();
         
         if (parser.hasOptionFilterLabels()) {
-            if (parser.getOptionValuesFilterLables() == null) {   
+            if (parser.getOptionValuesFilterLabels() == null) {
                 listOfFilters.add(new FilterByLabel(FILTERING_WORDS));
             } else {
                 listOfFilters.add(new FilterByLabel(
-                        Arrays.asList(parser.getOptionValuesFilterLables())));
+                        Arrays.asList(parser.getOptionValuesFilterLabels())));
             }
         }
         

--- a/Core/src/main/java/fi/muni/cz/core/factory/ProcessorFactory.java
+++ b/Core/src/main/java/fi/muni/cz/core/factory/ProcessorFactory.java
@@ -19,7 +19,7 @@ public class ProcessorFactory {
     public static List<String> getProcessorsRanWithInfoAsList(ArgsParser parser) {
         List<String> list = new ArrayList<>();
         for (IssuesProcessor processor: getProcessors(parser)) {
-            list.add(processor.infoAboutProcessor());
+            list.add(processor.infoAboutIssueProcessingAction());
         }
         return list;
     }

--- a/Core/src/main/java/fi/muni/cz/core/factory/ProcessorFactory.java
+++ b/Core/src/main/java/fi/muni/cz/core/factory/ProcessorFactory.java
@@ -1,7 +1,7 @@
 package fi.muni.cz.core.factory;
 
 import fi.muni.cz.core.ArgsParser;
-import fi.muni.cz.dataprocessing.issuesprocessing.IssuesProcessor;
+import fi.muni.cz.dataprocessing.issuesprocessing.IssueProcessingAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +18,7 @@ public class ProcessorFactory {
      */
     public static List<String> getProcessorsRanWithInfoAsList(ArgsParser parser) {
         List<String> list = new ArrayList<>();
-        for (IssuesProcessor processor: getProcessors(parser)) {
+        for (IssueProcessingAction processor: getProcessors(parser)) {
             list.add(processor.infoAboutIssueProcessingAction());
         }
         return list;
@@ -30,8 +30,8 @@ public class ProcessorFactory {
      * @param parser  parsed CommandLine.
      * @return list of Processors.
      */
-    public static List<IssuesProcessor> getProcessors(ArgsParser parser) {
-        List<IssuesProcessor> listOfProcessors = new ArrayList<>();
+    public static List<IssueProcessingAction> getProcessors(ArgsParser parser) {
+        List<IssueProcessingAction> listOfProcessors = new ArrayList<>();
 
         //Implement for processors
 

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/Filter.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/Filter.java
@@ -1,28 +1,9 @@
 package fi.muni.cz.dataprocessing.issuesprocessing;
 
-import fi.muni.cz.dataprovider.GeneralIssue;
-import java.util.List;
-
 /**
  * Represents classes that in some way filter List of 
  * {@link fi.muni.cz.reliability.tool.dataprovider.GeneralIssue}
  * 
  * @author Radoslav Micko, 445611@muni.cz
  */
-public interface Filter {
-    
-    /**
-     * Filter list of GeneralIssue 
-     * 
-     * @param list to be filtered
-     * @return List filtered list
-     */
-    List<GeneralIssue> filter(List<GeneralIssue> list);
-    
-    /**
-     * Information about filter used with atributes.
-     * 
-     * @return String info
-     */
-    String infoAboutFilter();
-}
+public interface Filter extends IssueProcessingAction {}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
@@ -25,7 +25,7 @@ public class FilterByLabel implements Filter, Serializable {
     }
     
     @Override
-    public List<GeneralIssue> filter(List<GeneralIssue> list) {
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
         if (filteringWords.isEmpty()) {
             throw new DataProcessingException("No filtering words");
         }
@@ -71,11 +71,11 @@ public class FilterByLabel implements Filter, Serializable {
      */
     private List<GeneralIssue> allLabelsToLowerCase(List<GeneralIssue> list) {
         IssuesProcessor toLowerCaseProcessor = new LabelsToLowerCaseProcessor();
-        return toLowerCaseProcessor.process(list);
+        return toLowerCaseProcessor.apply(list);
     }
 
     @Override
-    public String infoAboutFilter() {
+    public String infoAboutIssueProcessingAction() {
         return "FilterByLabel used, with filtering words: " + filteringWords;
     }
 

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
@@ -13,6 +13,8 @@ import java.util.List;
  */
 public class FilterByLabel implements Filter, Serializable {
 
+    private int issueAmountBefore;
+    private int issueAmountAfter;
     private final List<String> filteringWords;
 
     /**
@@ -26,10 +28,14 @@ public class FilterByLabel implements Filter, Serializable {
     
     @Override
     public List<GeneralIssue> apply(List<GeneralIssue> list) {
+        issueAmountBefore = list.size();
         if (filteringWords.isEmpty()) {
             throw new DataProcessingException("No filtering words");
         }
-        return filterByLabels(allLabelsToLowerCase(list));
+
+        List<GeneralIssue> result = filterByLabels(allLabelsToLowerCase(list));
+        issueAmountAfter = result.size();
+        return result;
     }
     
     /**
@@ -77,6 +83,11 @@ public class FilterByLabel implements Filter, Serializable {
     @Override
     public String infoAboutIssueProcessingAction() {
         return "FilterByLabel used, with filtering words: " + filteringWords;
+    }
+
+    @Override
+    public String infoAboutApplicationResult(){
+        return String.format("Removed %d issue reports", issueAmountBefore - issueAmountAfter);
     }
 
     @Override

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
@@ -52,6 +52,6 @@ public class FilterByTime implements Filter {
 
     @Override
     public String toString() {
-        return "FilterByTime";
+        return "FilterByTime: " + startOfTesting + " - " + endOfTesting;
     }
 }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
@@ -12,6 +12,8 @@ public class FilterByTime implements Filter {
 
     private final Date startOfTesting;
     private final Date endOfTesting;
+    private int issueAmountBefore;
+    private int issueAmountAfter;
     
     /**
      * Initialize.
@@ -26,12 +28,14 @@ public class FilterByTime implements Filter {
     
     @Override
     public List<GeneralIssue> apply(List<GeneralIssue> list) {
+        issueAmountBefore = list.size();
         List<GeneralIssue> filteredList = new ArrayList<>();
         for (GeneralIssue issue: list) {
             if (issue.getCreatedAt().after(startOfTesting) && issue.getCreatedAt().before(endOfTesting)) {
                 filteredList.add(issue);
             }
         }
+        issueAmountAfter = filteredList.size();
         return filteredList;
     }
 
@@ -40,7 +44,12 @@ public class FilterByTime implements Filter {
         return "FilterByTime start of testing = " + startOfTesting 
                 + ", end of testing = " + endOfTesting;
     }
-    
+
+    @Override
+    public String infoAboutApplicationResult(){
+        return String.format("Removed %d issue reports", issueAmountBefore - issueAmountAfter);
+    }
+
     @Override
     public String toString() {
         return "FilterByTime";

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTime.java
@@ -25,7 +25,7 @@ public class FilterByTime implements Filter {
     }
     
     @Override
-    public List<GeneralIssue> filter(List<GeneralIssue> list) {
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
         List<GeneralIssue> filteredList = new ArrayList<>();
         for (GeneralIssue issue: list) {
             if (issue.getCreatedAt().after(startOfTesting) && issue.getCreatedAt().before(endOfTesting)) {
@@ -36,7 +36,7 @@ public class FilterByTime implements Filter {
     }
 
     @Override
-    public String infoAboutFilter() {
+    public String infoAboutIssueProcessingAction() {
         return "FilterByTime start of testing = " + startOfTesting 
                 + ", end of testing = " + endOfTesting;
     }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosed.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosed.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class FilterClosed implements Filter, Serializable {
 
     @Override
-    public List<GeneralIssue> filter(List<GeneralIssue> list) {
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
         List<GeneralIssue> cloesedIssues = new ArrayList<>();
         for (GeneralIssue issue: list) {
             if (issue.getState().equals("closed")) {
@@ -25,7 +25,7 @@ public class FilterClosed implements Filter, Serializable {
     }
 
     @Override
-    public String infoAboutFilter() {
+    public String infoAboutIssueProcessingAction() {
         return "FilterClosed used to filter out opened issues.";
     }
     

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosed.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosed.java
@@ -13,22 +13,31 @@ import java.util.List;
  */
 public class FilterClosed implements Filter, Serializable {
 
+    private int issueAmountBefore;
+    private int issueAmountAfter;
+
     @Override
     public List<GeneralIssue> apply(List<GeneralIssue> list) {
-        List<GeneralIssue> cloesedIssues = new ArrayList<>();
+        issueAmountBefore = list.size();
+        List<GeneralIssue> closedIssues = new ArrayList<>();
         for (GeneralIssue issue: list) {
             if (issue.getState().equals("closed")) {
-                cloesedIssues.add(issue);
+                closedIssues.add(issue);
             }
         }
-        return cloesedIssues;
+        issueAmountAfter = closedIssues.size();
+        return closedIssues;
     }
 
     @Override
     public String infoAboutIssueProcessingAction() {
         return "FilterClosed used to filter out opened issues.";
     }
-    
+
+    @Override
+    public String infoAboutApplicationResult(){
+        return String.format("Removed %d issue reports", issueAmountBefore - issueAmountAfter);
+    }
     @Override
     public String toString() {
         return "FilterClosed";

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDefects.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDefects.java
@@ -19,8 +19,8 @@ public class FilterDefects implements Filter {
     private static final FilterByLabel FILTER_BY_LABELS = new FilterByLabel(FILTERING_WORDS);
 
     @Override
-    public List<GeneralIssue> filter(List<GeneralIssue> list) {
-        Set<GeneralIssue> filteredList = new HashSet<>(FILTER_BY_LABELS.filter(list));
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
+        Set<GeneralIssue> filteredList = new HashSet<>(FILTER_BY_LABELS.apply(list));
         for (GeneralIssue issue: list) {
             if (issue.getBody() == null) {
                 continue;
@@ -34,7 +34,7 @@ public class FilterDefects implements Filter {
     }
 
     @Override
-    public String infoAboutFilter() {
+    public String infoAboutIssueProcessingAction() {
         return "FilterDefects used to get only defects.";
     }
 

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDefects.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDefects.java
@@ -17,9 +17,12 @@ public class FilterDefects implements Filter {
 
     private static final List<String> FILTERING_WORDS = Arrays.asList("bug","error","fail","fault","defect");
     private static final FilterByLabel FILTER_BY_LABELS = new FilterByLabel(FILTERING_WORDS);
+    private int issueAmountBefore;
+    private int issueAmountAfter;
 
     @Override
     public List<GeneralIssue> apply(List<GeneralIssue> list) {
+        issueAmountBefore = list.size();
         Set<GeneralIssue> filteredList = new HashSet<>(FILTER_BY_LABELS.apply(list));
         for (GeneralIssue issue: list) {
             if (issue.getBody() == null) {
@@ -29,6 +32,7 @@ public class FilterDefects implements Filter {
                 filteredList.add(issue);
             }
         }
+        issueAmountAfter = filteredList.size();
         return filteredList.stream()
                 .sorted((a, b) -> a.getCreatedAt().compareTo(b.getCreatedAt())).collect(Collectors.toList());
     }
@@ -36,6 +40,11 @@ public class FilterDefects implements Filter {
     @Override
     public String infoAboutIssueProcessingAction() {
         return "FilterDefects used to get only defects.";
+    }
+
+    @Override
+    public String infoAboutApplicationResult(){
+        return String.format("Removed %d issue reports", issueAmountBefore - issueAmountAfter);
     }
 
     @Override

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDuplications.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDuplications.java
@@ -9,9 +9,11 @@ import java.util.List;
  * @author Radoslav Micko, 445611@muni.cz
  */
 public class FilterDuplications implements Filter {
-
+    private int issueAmountBefore;
+    private int issueAmountAfter;
     @Override
     public List<GeneralIssue> apply(List<GeneralIssue> list) {
+        issueAmountBefore = list.size();
         List<GeneralIssue> filteredList = new ArrayList<>();
         for (GeneralIssue issue: allLabelsToLowerCase(list)) {
             if (issue.getLabels().stream()
@@ -19,6 +21,7 @@ public class FilterDuplications implements Filter {
                 filteredList.add(issue);
             }
         }
+        issueAmountAfter = filteredList.size();
         return filteredList;
     }
 
@@ -27,6 +30,10 @@ public class FilterDuplications implements Filter {
         return "FilterDuplications used to remove duplication issues.";
     }
 
+    @Override
+    public String infoAboutApplicationResult(){
+        return String.format("Removed %d issue reports", issueAmountBefore - issueAmountAfter);
+    }
     @Override
     public String toString() {
         return "FilterDuplications";

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDuplications.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterDuplications.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class FilterDuplications implements Filter {
 
     @Override
-    public List<GeneralIssue> filter(List<GeneralIssue> list) {
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
         List<GeneralIssue> filteredList = new ArrayList<>();
         for (GeneralIssue issue: allLabelsToLowerCase(list)) {
             if (issue.getLabels().stream()
@@ -23,7 +23,7 @@ public class FilterDuplications implements Filter {
     }
 
     @Override
-    public String infoAboutFilter() {
+    public String infoAboutIssueProcessingAction() {
         return "FilterDuplications used to remove duplication issues.";
     }
 
@@ -34,6 +34,6 @@ public class FilterDuplications implements Filter {
 
     private List<GeneralIssue> allLabelsToLowerCase(List<GeneralIssue> list) {
         IssuesProcessor toLowerCaseProcessor = new LabelsToLowerCaseProcessor();
-        return toLowerCaseProcessor.process(list);
+        return toLowerCaseProcessor.apply(list);
     }
 }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingAction.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingAction.java
@@ -1,0 +1,28 @@
+package fi.muni.cz.dataprocessing.issuesprocessing;
+import fi.muni.cz.dataprovider.GeneralIssue;
+import java.util.List;
+
+/**
+ * Represents different data processing actions
+ * {@link fi.muni.cz.reliability.tool.dataprovider.GeneralIssue}
+ *
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ */
+
+public interface IssueProcessingAction {
+
+    /**
+     * Apply data processing action to provided list of general issues
+     *
+     * @param list that data processing action will be applied to
+     * @return List of general issues for which the data processing action has been applied to
+     */
+    List<GeneralIssue> apply(List<GeneralIssue> list);
+
+    /**
+     * Information about this data processing action.
+     *
+     * @return String info
+     */
+    String infoAboutIssueProcessingAction();
+}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingAction.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingAction.java
@@ -25,4 +25,11 @@ public interface IssueProcessingAction {
      * @return String info
      */
     String infoAboutIssueProcessingAction();
+
+    /**
+     * Information about the result of applying this data processing action.
+     *
+     * @return String info
+     */
+    String infoAboutApplicationResult();
 }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
@@ -35,7 +35,7 @@ public class IssueProcessingStrategy {
     public List<GeneralIssue> apply(List<GeneralIssue> issues){
         List<GeneralIssue> issueList = issues;
         for(IssueProcessingAction action : issueProcessingActionList){
-            issueList = checkListForEmpty(action.apply(issues));
+            issueList = checkListForEmpty(action.apply(issueList));
         }
         return issueList;
     }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
@@ -1,0 +1,48 @@
+package fi.muni.cz.dataprocessing.issuesprocessing;
+
+import fi.muni.cz.dataprovider.GeneralIssue;
+import java.util.List;
+
+/**
+ * Class that represents an issue processing strategy.
+ * Consists of several issue processing actions.
+ *
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ */
+
+public class IssueProcessingStrategy {
+
+    private final String name;
+    private final List<IssueProcessingAction> issueProcessingActionList;
+
+    /**
+     * Constructor.
+     * @param issueProcessingActions list of issue processing actions included in this strategy
+     * @param strategyName name for the data processing strategy
+     */
+    public IssueProcessingStrategy(List<IssueProcessingAction> issueProcessingActions, String strategyName){
+        name = strategyName;
+        issueProcessingActionList = issueProcessingActions;
+    }
+
+    /**
+     * Apply issue processing strategy on list of issue reports.
+     * @param issues Target list of issues
+     * @return List of issue reports that the data processing strategy has been applied to.
+     */
+    public List<GeneralIssue> apply(List<GeneralIssue> issues){
+        List<GeneralIssue> issueList = issues;
+        for(IssueProcessingAction action : issueProcessingActionList){
+            issueList = checkListForEmpty(action.apply(issues));
+        }
+        return issueList;
+    }
+
+    private static List<GeneralIssue> checkListForEmpty(List<GeneralIssue> issueList) {
+        if (issueList.isEmpty()) {
+            System.out.println("[There are no issues after applying data processing action]");
+            System.exit(1);
+        }
+        return issueList;
+    }
+}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssueProcessingStrategy.java
@@ -2,6 +2,8 @@ package fi.muni.cz.dataprocessing.issuesprocessing;
 
 import fi.muni.cz.dataprovider.GeneralIssue;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Class that represents an issue processing strategy.
@@ -36,6 +38,19 @@ public class IssueProcessingStrategy {
             issueList = checkListForEmpty(action.apply(issues));
         }
         return issueList;
+    }
+
+    /**
+     * Get info about issue processing action results.
+     * Should be used after strategy has been applied on data.
+     * @return Issue processing strategy action results.
+     */
+    public Map<String, String> getIssueProcessingActionResults() {
+        return issueProcessingActionList.stream()
+                .collect(Collectors.toMap(
+                        IssueProcessingAction::toString,
+                        IssueProcessingAction::infoAboutApplicationResult
+                ));
     }
 
     private static List<GeneralIssue> checkListForEmpty(List<GeneralIssue> issueList) {

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssuesProcessor.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/IssuesProcessor.java
@@ -1,27 +1,8 @@
 package fi.muni.cz.dataprocessing.issuesprocessing;
 
-import fi.muni.cz.dataprovider.GeneralIssue;
-import java.util.List;
-
 /**
  * Represents classes that in some way process List of GeneralIssue
  * 
  * @author Radoslav Micko, 445611@muni.cz
  */
-public interface IssuesProcessor {
-    
-    /**
-     * Process list of GeneralIssue 
-     * 
-     * @param list to be processed
-     * @return List processed list
-     */
-    List<GeneralIssue> process(List<GeneralIssue> list);
-    
-    /**
-     * Information about processor used with attributes.
-     * 
-     * @return String info
-     */
-    String infoAboutProcessor();
-}
+public interface IssuesProcessor extends IssueProcessingAction {}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessor.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessor.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class LabelsToLowerCaseProcessor implements IssuesProcessor {
     
     @Override
-    public List<GeneralIssue> process(List<GeneralIssue> list) {
+    public List<GeneralIssue> apply(List<GeneralIssue> list) {
         for (GeneralIssue issue: list) {
             issue.allLabelsToLowerCase();
         } 
@@ -17,7 +17,7 @@ public class LabelsToLowerCaseProcessor implements IssuesProcessor {
     }
 
     @Override
-    public String infoAboutProcessor() {
+    public String infoAboutIssueProcessingAction() {
         return "LabelsToLowerCaseProcessor used to lowercase all lables of issues.";
     }
     

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessor.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessor.java
@@ -20,6 +20,11 @@ public class LabelsToLowerCaseProcessor implements IssuesProcessor {
     public String infoAboutIssueProcessingAction() {
         return "LabelsToLowerCaseProcessor used to lowercase all lables of issues.";
     }
+
+    @Override
+    public String infoAboutApplicationResult(){
+        return "Labels now use lowercase.";
+    }
     
     @Override
     public String toString() {

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/OutputData.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/OutputData.java
@@ -43,6 +43,8 @@ public class OutputData implements Serializable {
     private String testingPeriodsUnit;
     private List<String> filtersUsed;
     private List<String> processorsUsed;
+
+    private Map<String, String> issueProcessingActionResults;
     private String solver;
 
     private List<ReleaseDTO> releases;
@@ -73,6 +75,7 @@ public class OutputData implements Serializable {
         this.testingPeriodsUnit = builder.testingPeriodsUnit;
         this.filtersUsed = builder.filtersUsed;
         this.processorsUsed = builder.processorsUsed;
+        this.issueProcessingActionResults = builder.issueProcessingActionResults;
         this.solver = builder.solver;
         this.repositoryContributors = builder.repositoryContributors;
         this.repositoryDescription = builder.repositoryDescription;
@@ -133,6 +136,14 @@ public class OutputData implements Serializable {
 
     public void setProcessorsUsed(List<String> processorsUsed) {
         this.processorsUsed = processorsUsed;
+    }
+
+    public Map<String, String> getIssueProcessingActionResults() {
+        return issueProcessingActionResults;
+    }
+
+    public void setIssueProcessingActionResults(Map<String, String> actionResults) {
+        this.issueProcessingActionResults = actionResults;
     }
     
     public boolean isExistTrend() {
@@ -389,6 +400,8 @@ public class OutputData implements Serializable {
         private String testingPeriodsUnit;
         private List<String> filtersUsed;
         private List<String> processorsUsed;
+
+        private Map<String, String> issueProcessingActionResults;
         private String solver;
 
         private List<ReleaseDTO> releases;
@@ -610,6 +623,17 @@ public class OutputData implements Serializable {
          */
         public OutputDataBuilder setProcessorsUsed(List<String> processorsUsed) {
             this.processorsUsed = processorsUsed;
+            return this;
+        }
+
+        /**
+         * Set issue processing action results.
+         *
+         * @param actionResults list of processors used.
+         * @return this builder, to allow method chaining.
+         */
+        public OutputDataBuilder setIssueProcessingActionResults(Map<String, String> actionResults) {
+            this.issueProcessingActionResults = actionResults;
             return this;
         }
 

--- a/DataProcessing/src/main/resources/templates/template_empty.html
+++ b/DataProcessing/src/main/resources/templates/template_empty.html
@@ -90,29 +90,26 @@
             <p>
                 Estimated at <b>${noModelsData.createdAt?datetime}</b>.
             </p>
-            <p>
-                Initial number of total defects = ${noModelsData.initialNumberOfIssues}<br>
-                Total defects in repository after processing and filtering = ${noModelsData.totalNumberOfDefects}<br>
-            </p>
-            <h3>Filters and Processors:</h3>
-            <p>
-                <b>Filters:</b><br>
-                <#if noModelsData.filtersUsed?size != 0>
-                <#list noModelsData.filtersUsed as value>
-                - ${value}<br>
-            </#list>
-            <#else>
-            - None<br>
-        </#if>
-        <b>Processors:</b><br>
-        <#if noModelsData.processorsUsed?size != 0>
-        <#list noModelsData.processorsUsed as value>
-        - ${value}<br>
-    </#list>
-    <#else>
-    - None<br>
-</#if>
-</p>
+        <h3>Data processing overview</h3>
+        <p>
+            Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
+            Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
+        </p>
+        <b>Issue processing action results:</b><br>
+        <table>
+            <tr>
+                <th>Issue processing action</th>
+                <th>Issue processing action result</th>
+            </tr>
+            <#if dataList[0].issueProcessingActionResults?size != 0>
+                <#list dataList[0].issueProcessingActionResults as key, value>
+                    <tr>
+                        <td>${key}</td>
+                        <td>${value}</td>
+                    </tr>
+                </#list>
+            </#if>
+        </table>
 <h3>Trend test:</h3>
 <p>
     Trend ${noModelsData.existTrend?string("exists", "does not exist")} .<br>

--- a/DataProcessing/src/main/resources/templates/template_empty.html
+++ b/DataProcessing/src/main/resources/templates/template_empty.html
@@ -92,8 +92,8 @@
             </p>
         <h3>Data processing overview</h3>
         <p>
-            Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
-            Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
+            Initial number of total defects = ${noModelsData.initialNumberOfIssues}<br>
+            Total defects in repository after processing and filtering = ${noModelsData.totalNumberOfDefects}<br>
         </p>
         <b>Issue processing action results:</b><br>
         <table>
@@ -101,8 +101,8 @@
                 <th>Issue processing action</th>
                 <th>Issue processing action result</th>
             </tr>
-            <#if dataList[0].issueProcessingActionResults?size != 0>
-                <#list dataList[0].issueProcessingActionResults as key, value>
+            <#if noModelsData.issueProcessingActionResults?size != 0>
+                <#list noModelsData.issueProcessingActionResults as key, value>
                     <tr>
                         <td>${key}</td>
                         <td>${value}</td>

--- a/DataProcessing/src/main/resources/templates/template_one.html
+++ b/DataProcessing/src/main/resources/templates/template_one.html
@@ -91,16 +91,16 @@
                 </p>
                 <h3>Data processing overview</h3>
                 <p>
-                    Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
-                    Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
+                    Initial number of total defects = ${data.initialNumberOfIssues}<br>
+                    Total defects in repository after processing and filtering = ${data.totalNumberOfDefects}<br>
                 </p>
                 <table>
                     <tr>
                         <th>Issue processing action</th>
                         <th>Issue processing action result</th>
                     </tr>
-                    <#if dataList[0].issueProcessingActionResults?size != 0>
-                        <#list dataList[0].issueProcessingActionResults as key, value>
+                    <#if data.issueProcessingActionResults?size != 0>
+                        <#list data.issueProcessingActionResults as key, value>
                             <tr>
                                 <td>${key}</td>
                                 <td>${value}</td>

--- a/DataProcessing/src/main/resources/templates/template_one.html
+++ b/DataProcessing/src/main/resources/templates/template_one.html
@@ -89,29 +89,25 @@
                 <p>
                     Estimated at <b>${data.createdAt?datetime}</b>.
                 </p>
+                <h3>Data processing overview</h3>
                 <p>
-                    Initial number of total defects = ${data.initialNumberOfIssues}<br>
-                    Total defects in repository after processing and filtering = ${data.totalNumberOfDefects}<br>
+                    Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
+                    Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
                 </p>
-                <h3>Filters and Processors:</h3>
-                <p> 
-                <b>Filters:</b><br>
-                <#if data.filtersUsed?size != 0>
-                    <#list data.filtersUsed as value> 
-                        - ${value}<br>
-                    </#list>
-                <#else>
-                    - None<br>
-                </#if>
-                <b>Processors:</b><br>
-                <#if data.processorsUsed?size != 0>
-                    <#list data.processorsUsed as value> 
-                        - ${value}<br>
-                    </#list>
-                <#else>
-                    - None<br>
-                </#if>
-                </p>
+                <table>
+                    <tr>
+                        <th>Issue processing action</th>
+                        <th>Issue processing action result</th>
+                    </tr>
+                    <#if dataList[0].issueProcessingActionResults?size != 0>
+                        <#list dataList[0].issueProcessingActionResults as key, value>
+                            <tr>
+                                <td>${key}</td>
+                                <td>${value}</td>
+                            </tr>
+                        </#list>
+                    </#if>
+                </table>
                 <h3>Trend test:</h3>
                 <p>
                     Trend ${data.existTrend?string("exists", "does not exist")} .<br>

--- a/DataProcessing/src/main/resources/templates/template_three.html
+++ b/DataProcessing/src/main/resources/templates/template_three.html
@@ -117,29 +117,26 @@
                     <p>
                         Estimated at <b>${dataList[0].createdAt?datetime}</b>.
                     </p>
+                    <h3>Data processing overview</h3>
                     <p>
                         Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
                         Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
                     </p>
-                    <h3>Filters and Processors:</h3>
-                    <p> 
-                        <b>Filters:</b><br>
-                            <#if dataList[0].filtersUsed?size != 0>
-                                <#list dataList[0].filtersUsed as value> 
-                                    - ${value}<br>
-                                </#list>
-                            <#else>
-                                - None<br>
-                            </#if>
-                        <b>Processors:</b><br>
-                            <#if dataList[0].processorsUsed?size != 0>
-                                <#list dataList[0].processorsUsed as value> 
-                                    - ${value}<br>
-                                </#list>
-                            <#else>
-                                - None<br>
-                            </#if>
-                    </p>
+                    <b>Issue processing action results:</b><br>
+                    <table>
+                        <tr>
+                            <th>Issue processing action</th>
+                            <th>Issue processing action result</th>
+                        </tr>
+                        <#if dataList[0].issueProcessingActionResults?size != 0>
+                            <#list dataList[0].issueProcessingActionResults as key, value>
+                                <tr>
+                                    <td>${key}</td>
+                                    <td>${value}</td>
+                                </tr>
+                            </#list>
+                        </#if>
+                    </table>
                     <h3>Trend test:</h3> 
                     <p>
                         Trend ${dataList[0].existTrend?string("exists", "does not exist")} .<br>

--- a/DataProcessing/src/main/resources/templates/template_two.html
+++ b/DataProcessing/src/main/resources/templates/template_two.html
@@ -116,29 +116,26 @@
                     <p>
                         Estimated at <b>${dataList[0].createdAt?datetime}</b>.
                     </p>
+                    <h3>Data processing overview</h3>
                     <p>
                         Initial number of total defects = ${dataList[0].initialNumberOfIssues}<br>
                         Total defects in repository after processing and filtering = ${dataList[0].totalNumberOfDefects}<br>
                     </p>
-                    <h3>Filters and Processors:</h3>
-                    <p> 
-                        <b>Filters:</b><br>
-                            <#if dataList[0].filtersUsed?size != 0>
-                                <#list dataList[0].filtersUsed as value> 
-                                    - ${value}<br>
-                                </#list>
-                            <#else>
-                                - None<br>
-                            </#if>
-                        <b>Processors:</b><br>
-                            <#if dataList[0].processorsUsed?size != 0>
-                                <#list dataList[0].processorsUsed as value> 
-                                    - ${value}<br>
-                                </#list>
-                            <#else>
-                                - None<br>
-                            </#if>
-                    </p>
+                    <b>Issue processing action results:</b><br>
+                    <table>
+                        <tr>
+                            <th>Issue processing action</th>
+                            <th>Issue processing action result</th>
+                        </tr>
+                        <#if dataList[0].issueProcessingActionResults?size != 0>
+                            <#list dataList[0].issueProcessingActionResults as key, value>
+                                <tr>
+                                    <td>${key}</td>
+                                    <td>${value}</td>
+                                </tr>
+                            </#list>
+                        </#if>
+                    </table>
                     <h3>Trend test:</h3> 
                     <p>
                         Trend ${dataList[0].existTrend?string("exists", "does not exist")} .<br>

--- a/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabelNGTest.java
+++ b/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabelNGTest.java
@@ -37,12 +37,12 @@ public class FilterByLabelNGTest {
     
     @Test(expectedExceptions = DataProcessingException.class)
     public void testFilterWithNoWords() {
-        filterWithNoWords.filter(listOfIssues);
+        filterWithNoWords.apply(listOfIssues);
     }
     
     @Test
     public void testFilterWithWords() {
-        assertEquals(filterForWordError.filter(listOfIssues).size(), 1);
-        assertEquals(filterForSomeWord.filter(listOfIssues).size(), 0);
+        assertEquals(filterForWordError.apply(listOfIssues).size(), 1);
+        assertEquals(filterForSomeWord.apply(listOfIssues).size(), 0);
     }
 }

--- a/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTimeNGTest.java
+++ b/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByTimeNGTest.java
@@ -54,16 +54,16 @@ public class FilterByTimeNGTest {
         Date end = cal.getTime();
         
         Filter filter = new FilterByTime(start, end);
-        assertEquals(filter.filter(listOfIssues).size(), 1);
+        assertEquals(filter.apply(listOfIssues).size(), 1);
         
         cal.set(2018, 10, 8, 0, 0, 0);
         end = cal.getTime();
         filter = new FilterByTime(start, end);
-        assertEquals(filter.filter(listOfIssues).size(), 4);
+        assertEquals(filter.apply(listOfIssues).size(), 4);
         
         cal.set(2018, 10, 2, 0, 0, 0);
         start = cal.getTime();
         filter = new FilterByTime(start, end);
-        assertEquals(filter.filter(listOfIssues).size(), 2);
+        assertEquals(filter.apply(listOfIssues).size(), 2);
     }
 }

--- a/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosedNGTest.java
+++ b/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterClosedNGTest.java
@@ -31,7 +31,7 @@ public class FilterClosedNGTest {
     
     @Test
     public void testFilterClosed() {
-        assertEquals(filter.filter(listOfIssues).size(), 1);
-        assertEquals(filter.filter(listOfIssuesNoClosed).size(), 0);
+        assertEquals(filter.apply(listOfIssues).size(), 1);
+        assertEquals(filter.apply(listOfIssuesNoClosed).size(), 0);
     }
 }

--- a/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessorNGTest.java
+++ b/DataProcessing/src/test/java/fi/muni/cz/dataprocessing/issuesprocessing/LabelsToLowerCaseProcessorNGTest.java
@@ -26,8 +26,8 @@ public class LabelsToLowerCaseProcessorNGTest {
     
     @Test
     public void testLabelsToLowerCase() {
-        assertEquals(processor.process(listOfIssues).get(0).getLabels().get(0), "bug");
-        assertEquals(processor.process(listOfIssues).get(0).getLabels().get(1), "error");
-        assertEquals(processor.process(listOfIssues).get(0).getLabels().get(2), "fault");
+        assertEquals(processor.apply(listOfIssues).get(0).getLabels().get(0), "bug");
+        assertEquals(processor.apply(listOfIssues).get(0).getLabels().get(1), "error");
+        assertEquals(processor.apply(listOfIssues).get(0).getLabels().get(2), "fault");
     }
 }


### PR DESCRIPTION
This PR adds a new table to the STRAIT HTML output.
The table shows the issue processing actions used in the reliability analysis, as well as the result of applying that action to the issue data. This should help with estimating the effects each strategy action has on the end result.

Before:

<img width="630" alt="image" src="https://github.com/stanozm/STRAIT/assets/43828011/0d691392-603b-4057-9eb8-d7b73bd57086">

After:

<img width="610" alt="image" src="https://github.com/stanozm/STRAIT/assets/43828011/cc37255f-7f87-47d3-99dd-090ade5c81ea">


In addition, the old code is refactored to use new IssueProcessingAction and IssueProcessingStrategy classes.
This made implementing the issue processing action table easier.
It may also help with future changes, for instance when the grouping strategies are implemented.