### PR TITLE
Add batch analysis functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,12 @@ hs_err_pid*
 
 nbproject/
 target/
-output/
 .idea/
 .vscode/
 git_hub_authentication_file.properties
 log.out
 .DS_store
+batchConfig.json
+batchConfigSmall.json
 Reliability-Tool-Core/IssuesDB/
 *.txt

--- a/Core/src/main/java/fi/muni/cz/core/Core.java
+++ b/Core/src/main/java/fi/muni/cz/core/Core.java
@@ -1,5 +1,7 @@
 package fi.muni.cz.core;
 
+import fi.muni.cz.core.configuration.BatchAnalysisConfiguration;
+import fi.muni.cz.core.configuration.DataSource;
 import fi.muni.cz.core.exception.InvalidInputException;
 import fi.muni.cz.core.factory.*;
 import fi.muni.cz.dataprocessing.issuesprocessing.IssueProcessingStrategy;
@@ -27,6 +29,7 @@ import org.rosuda.JRI.Rengine;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +81,10 @@ public class Core {
                break;
             case HELP:
                 PARSER.printHelp();
+                break;
+            case BATCH_AND_EVALUATE:
+                doBatchAnalysis();
+                break;
             case URL_AND_SAVE:
                 checkUrl(PARSER.getOptionValueUrl());
                 doSaveToFileFromUrl();
@@ -114,6 +121,20 @@ public class Core {
         }
         System.out.println("Done! Duration - " + Duration.between(start, Instant.now()).toMinutes() + "min");
         System.exit(0);
+    }
+
+    private static void doBatchAnalysis() throws InvalidInputException {
+        System.out.println("Starting batch processing");
+        List<String> errors = Collections.EMPTY_LIST;
+        String filePath = PARSER.getOptionValueBatchConfigurationFile();
+        BatchAnalysisConfiguration batchConfiguration =
+                PARSER.parseBatchAnalysisConfigurationFromFile(filePath, errors);
+        if(errors.isEmpty()){
+            for(DataSource dataSource : batchConfiguration.getDataSources()){
+                checkUrl(dataSource.getLocation());
+                doEvaluateForUrl();
+            }
+        }
     }
     
     private static void  doEvaluateForUrl() throws InvalidInputException {

--- a/Core/src/main/java/fi/muni/cz/core/RunConfiguration.java
+++ b/Core/src/main/java/fi/muni/cz/core/RunConfiguration.java
@@ -6,6 +6,7 @@ package fi.muni.cz.core;
 public enum RunConfiguration {
     HELP,
     LIST_ALL_SNAPSHOTS,
+    BATCH_AND_EVALUATE,
     URL_AND_SAVE,
     URL_AND_LIST_SNAPSHOTS,
     URL_AND_EVALUATE,

--- a/Core/src/main/java/fi/muni/cz/core/configuration/BatchAnalysisConfiguration.java
+++ b/Core/src/main/java/fi/muni/cz/core/configuration/BatchAnalysisConfiguration.java
@@ -1,0 +1,28 @@
+package fi.muni.cz.core.configuration;
+
+import java.util.List;
+
+/**
+ * Class that represents a configuration for batch analysis.
+ * Contains data source information that is used in analysis.
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ * */
+public class BatchAnalysisConfiguration {
+
+    private List<DataSource> dataSources;
+
+    /**
+     * @return data sources
+     */
+    public List<DataSource> getDataSources() {
+        return dataSources;
+    }
+
+    /**
+     * Set data sources
+     * @param dataSources list of data sources
+     * */
+    public void setDataSources(List<DataSource> dataSources) {
+        this.dataSources = dataSources;
+    }
+}

--- a/Core/src/main/java/fi/muni/cz/core/configuration/DataSource.java
+++ b/Core/src/main/java/fi/muni/cz/core/configuration/DataSource.java
@@ -1,0 +1,23 @@
+package fi.muni.cz.core.configuration;
+
+/**
+ * Class that represents a data source.
+ * This could be a Github URL, path to a JIRA CSV file etc.
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ * */
+
+public class DataSource {
+    private String type;
+    private String location;
+
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return data source location (url or file path)
+     */
+    public String getLocation() {
+        return location;
+    }
+}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/issuesprocessing/FilterByLabel.java
@@ -5,6 +5,7 @@ import fi.muni.cz.dataprovider.GeneralIssue;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Filtering list of GeneralIssue by labels
@@ -92,6 +93,6 @@ public class FilterByLabel implements Filter, Serializable {
 
     @Override
     public String toString() {
-        return "FilterByLabel" + filteringWords;
+        return "FilterByLabel" + filteringWords.stream().map(str -> str + " ").collect(Collectors.joining());
     }
 }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/BatchOutputWriter.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/BatchOutputWriter.java
@@ -1,0 +1,18 @@
+package fi.muni.cz.dataprocessing.output;
+
+import java.util.List;
+
+/**
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ */
+public interface BatchOutputWriter {
+    
+    /**
+     * Write batch analysis output data to a file.
+     * A batch analysis involves multiple data sources.
+     * 
+     * @param outputData data to write 
+     * @param fileName name of file
+     */
+    void writeBatchOutputDataToFile(List<List<OutputData>> outputData, String fileName);
+}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvFileBatchAnalysisReportWriter.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvFileBatchAnalysisReportWriter.java
@@ -1,0 +1,89 @@
+package fi.muni.cz.dataprocessing.output;
+
+import static fi.muni.cz.dataprocessing.output.CsvUtil.CSV_FILE_SUFFIX;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.NEW_LINE_SEPARATOR;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.eliminateSeparatorAndCheckNullValue;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.writeElementWithDelimiter;
+
+import fi.muni.cz.dataprocessing.exception.DataProcessingException;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ */
+public class CsvFileBatchAnalysisReportWriter implements BatchOutputWriter {
+    private static final String FILE_HEADER = "Project name,Trend test,Total issues,Defects used for fitting,";
+
+    @Override
+    public void writeBatchOutputDataToFile(List<List<OutputData>> list, String fileName) {
+        String filePath = "./output/" + fileName + CSV_FILE_SUFFIX;
+        File file = new File(filePath);
+        System.out.println("Writing batch result report to path " + filePath);
+        try (FileWriter fileWriter = new FileWriter(file)){
+            if(list.isEmpty() || list.get(0).isEmpty()){
+                System.out.println("Batch report writing failed.");
+                throw new DataProcessingException("No output data with which to write batch report");
+            }
+
+            List<String> goodnessOfFitKeys = new ArrayList<>(
+                    list.get(0).get(0)
+                            .getGoodnessOfFit().keySet()
+            ).stream().sorted().collect(Collectors.toList());
+
+            List<String> issueProcessingStrategyResultKeys = new ArrayList<>(
+                    list.get(0).get(0)
+                            .getIssueProcessingActionResults().keySet()
+            ).stream().sorted().collect(Collectors.toList());
+
+            String modelResultHeaders = list.get(0).stream().flatMap(outputData -> {
+                String modelName = outputData.getModelName();
+                List<String> headers = goodnessOfFitKeys.stream().map(testName -> modelName + " " +  testName + ",")
+                        .collect(Collectors.toList());
+                return headers.stream();
+            }).collect(Collectors.joining());
+
+            String issueProcessingStrategyResultHeaders = issueProcessingStrategyResultKeys
+                    .stream()
+                    .map(str -> str + ",")
+                    .collect(Collectors.joining());
+
+            String extendedHeader = FILE_HEADER + modelResultHeaders + issueProcessingStrategyResultHeaders;
+
+
+            fileWriter.append(extendedHeader);
+            fileWriter.append(NEW_LINE_SEPARATOR);
+            for (List<OutputData> outputs : list) {
+                writeElementWithDelimiter(
+                        eliminateSeparatorAndCheckNullValue(outputs.get(0).getRepositoryName()), fileWriter);
+                writeElementWithDelimiter(
+                        eliminateSeparatorAndCheckNullValue(outputs.get(0).isExistTrend()), fileWriter);
+                writeElementWithDelimiter(
+                        eliminateSeparatorAndCheckNullValue(outputs.get(0).getInitialNumberOfIssues()), fileWriter);
+                writeElementWithDelimiter(
+                        eliminateSeparatorAndCheckNullValue(outputs.get(0).getTotalNumberOfDefects()), fileWriter);
+
+                for (OutputData output : outputs) {
+                    for (String testName : goodnessOfFitKeys){
+                        writeElementWithDelimiter(eliminateSeparatorAndCheckNullValue(
+                                output.getGoodnessOfFit().get(testName)), fileWriter);
+                    }
+                }
+
+                for(String resultName : issueProcessingStrategyResultKeys){
+                    writeElementWithDelimiter(eliminateSeparatorAndCheckNullValue(
+                            outputs.get(0).getIssueProcessingActionResults().get(resultName)), fileWriter);
+                }
+
+                fileWriter.append(NEW_LINE_SEPARATOR);
+            }
+        } catch (Exception ex) {
+            System.out.println("Batch report writing failed.");
+            throw new DataProcessingException("Error while creating csv file.", ex);
+        }
+    }
+
+}

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvFileIssuesWriter.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvFileIssuesWriter.java
@@ -1,5 +1,10 @@
 package fi.muni.cz.dataprocessing.output;
 
+import static fi.muni.cz.dataprocessing.output.CsvUtil.CSV_FILE_SUFFIX;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.NEW_LINE_SEPARATOR;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.eliminateSeparatorAndCheckNullValue;
+import static fi.muni.cz.dataprocessing.output.CsvUtil.writeElementWithDelimiter;
+
 import fi.muni.cz.dataprocessing.exception.DataProcessingException;
 import fi.muni.cz.dataprovider.GeneralIssue;
 import java.io.File;
@@ -11,10 +16,6 @@ import java.util.List;
  * @author Radoslav Micko, 445611@muni.cz
  */
 public class CsvFileIssuesWriter implements IssuesWriter {
-    private static final String CSV_FILE_SUFFIX = ".csv";
-    private static final String COMMA_DELIMITER = "\t";
-    private static final String NEW_LINE_SEPARATOR = "\n";
-
     private static final String FILE_HEADER = "Created at\tClosed at\tUpdated at\tState\tLabels"
             + "\tComments\tNumber\tTitle\tUrl\tHtml url\tBody\tUser name\tUser email\tMilestone created at"
             + "\tMilestone due on\tMilestone descrtiption\tMilestone state\tMilestone title";
@@ -69,17 +70,5 @@ public class CsvFileIssuesWriter implements IssuesWriter {
             throw new DataProcessingException("Error while creating csv file.", ex);
         }
     } 
-    
-    private static String checkNullValueToString(Object obj) {
-        return obj == null ? "null" : obj.toString();
-    }
-    
-    private static void writeElementWithDelimiter(String element, FileWriter fileWriter) throws IOException {
-        fileWriter.append(element);
-        fileWriter.append(COMMA_DELIMITER);
-    }
 
-    private static String eliminateSeparatorAndCheckNullValue(Object obj) {
-        return checkNullValueToString(obj).replaceAll("\\t", " ").replaceAll("\\n", " ").replaceAll("\\v", " ");
-    }
 }

--- a/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvUtil.java
+++ b/DataProcessing/src/main/java/fi/muni/cz/dataprocessing/output/CsvUtil.java
@@ -1,0 +1,49 @@
+package fi.muni.cz.dataprocessing.output;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * @author Valtteri Valtonen, valtonenvaltteri@gmail.com
+ */
+public class CsvUtil {
+
+    public static final String CSV_FILE_SUFFIX = ".csv";
+    public static final String COMMA_DELIMITER = ",";
+    public static final String NEW_LINE_SEPARATOR = "\n";
+
+    /**
+     * Convert null objects to string form
+     * @param obj an object
+     * @return the string representation of the object or the string null if the  object is null
+     * */
+    public static String checkNullValueToString(Object obj) {
+        return obj == null ? "null" : obj.toString();
+    }
+
+    /**
+     * Write element to file using a delimiter
+     * @param element a string
+     * @param fileWriter file writer
+     * @throws IOException io exception
+     * */
+    public static void writeElementWithDelimiter(String element, FileWriter fileWriter) throws IOException {
+        fileWriter.append(element);
+        fileWriter.append(COMMA_DELIMITER);
+    }
+
+    /**
+     * Check object for null value and eliminate separators
+     * @param obj an object
+     * @return result of checkNullValueToString with separators eliminated
+     * */
+    public static String eliminateSeparatorAndCheckNullValue(Object obj) {
+        return checkNullValueToString(obj)
+                .replaceAll("\\t", " ")
+                .replaceAll("\\n", " ")
+                .replaceAll("\\v", " ");
+    }
+
+
+
+}

--- a/batchConfig.json
+++ b/batchConfig.json
@@ -1,0 +1,24 @@
+{
+  "dataSources": [
+    {
+      "type": "github",
+      "location": "https://github.com/ToolJet/ToolJet"
+    },
+    {
+      "type": "github",
+      "location": "https://github.com/huggingface/transformers"
+    },
+    {
+      "type": "github",
+      "location": "https://github.com/neovim/neovim"
+    },
+    {
+      "type": "github",
+      "location": "https://github.com/curl/curl"
+    },
+    {
+      "type": "github",
+      "location": "https://github.com/Gallopsled/pwntools"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds simple batch analysis functionality to STRAIT.

- Reliability analysis can now be performed for multiple projects with one command by supplying the program with a configuration file.
- HTML reports for the projects as well as a batch CSV report file are generated as output.

The configuration file is supplied with command line option -bcf .
The file should be a JSON file of the following form:

```
{
  "dataSources": [
    {
      "type": "github",
      "location": "https://github.com/ToolJet/ToolJet"
    },
    {
      "type": "github",
      "location": "https://github.com/huggingface/transformers"
    },
    {
      "type": "github",
      "location": "https://github.com/neovim/neovim"
    },
    {
      "type": "github",
      "location": "https://github.com/curl/curl"
    },
    {
      "type": "github",
      "location": "https://github.com/Gallopsled/pwntools"
    }
  ]
}
```

Other data source types such as snapshots, may be added in the future.